### PR TITLE
[Task2.2a] Controller Concurrency and Timing Implementation

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,4 +1,7 @@
+find_package(Threads REQUIRED)
+
 add_executable(shell-app main.cpp Controller.cpp Limits.cpp PID.cpp Model.cpp)
+target_link_libraries(shell-app Threads::Threads)
 include_directories(
   ${CMAKE_SOURCE_DIR}/include
 )

--- a/app/Controller.cpp
+++ b/app/Controller.cpp
@@ -13,19 +13,37 @@
 
 namespace ackermann {
 
-Controller::Controller(const Params& params) {
+using namespace std::chrono_literals;
+using std::chrono::steady_clock;
+using std::chrono::duration;
+
+Controller::Controller(const Params& params)
+  : params_(params) {
 }
 
 void Controller::start() {
+  // rejoin any existing thread
+  stop(true);
+
+  // spin off a thread processing our control loop
+  control_loop_handle_ = std::thread([this](){this->controlLoop();});
 }
 
-void Controller::stop() {
+void Controller::stop(bool block) {
+  // set cancel; optionally wait for the thread to return
+  cancel_ = true;
+  if (block && control_loop_handle_.joinable())
+    control_loop_handle_.join();
+
+  // reset class variables and composition classes
+  reset();
 }
 
 void Controller::reset() {
 }
 
 bool Controller::isRunning() const {
+  return running_;
 }
 
 void Controller::setState(const double heading, const double speed) {
@@ -44,6 +62,29 @@ void Controller::getCommand(double& throttle, double& steering) const {
 }
 
 void Controller::controlLoop() {
+  // core execution loop
+  running_ = true;
+  cancel_ = false;
+
+  // initialize timing variables
+  std::chrono::milliseconds duration(static_cast<int>(1000/params_.control_frequency));
+  auto next_loop_time = steady_clock::now();
+
+  // execute loop at the desired frequency
+  while (!cancel_) {
+    // update next target time
+    next_loop_time += duration;
+
+    //
+    // @TODO groundbreaking robotics goes here
+    //
+
+    // sleep until next loop
+    std::this_thread::sleep_until(next_loop_time);
+  }
+
+  // after we exit we should reset our state variables
+  running_ = false;
 }
 
 } // namespace ackermann

--- a/include/Controller.hpp
+++ b/include/Controller.hpp
@@ -9,9 +9,11 @@
  * @copyright [2020]
  */
 
+#include <assert.h>
 #include <atomic>
 #include <memory>
 #include <thread>
+#include <chrono>
 
 #include "Params.hpp"
 #include "Model.hpp"
@@ -29,10 +31,11 @@ class Controller {
   void start();
 
   /* @brief Stop execution of a control loop and rejoin.
-   *
    * This also calls reset() to clear any state variables.
+   * 
+   * @ param block: Optionally wait for any running thread to rejoin. Default false.
    */
-  void stop();
+  void stop(bool block = false);
 
   /* @brief Clear system state variables. */
   void reset();
@@ -97,6 +100,9 @@ class Controller {
   /* @brief Control loop (executed asynchronously) */
   void controlLoop();
 
+  /* @brief A copy of our configuration parameters. */
+  Params params_;
+
   /* @brief Ackermann model (used in translating 
    * speed/heading into wheel speeds)
    */
@@ -116,7 +122,7 @@ class Controller {
   /* @brief Thread handle for the currently executing control loop. */
   std::thread control_loop_handle_;
   std::atomic<bool> running_ {false};
-
+  std::atomic<bool> cancel_ {false};
 };
 
 } // namespace ackermann


### PR DESCRIPTION
This PR adds the basic structure of our core controller thread. It doesn't perform any logic, but now calling `start` on the Controller will spin off a thread that executes at the specified `control_frequency` until canceled (by a `stop` command).