### PR TITLE
[Task 2.7] Corrected order-of-initialization compiler warnings.

### DIFF
--- a/include/PID.hpp
+++ b/include/PID.hpp
@@ -67,11 +67,11 @@ class PID {
   // @brief Integral Error
   double integral_error_;
 
-  // @brief Output Maximum Limit (For PID windup)
-  double out_maxLimit_;
-
   //@brief Output Minimum Limit (For PID windup)
   double out_minLimit_;
+
+  // @brief Output Maximum Limit (For PID windup)
+  double out_maxLimit_;
 };
 
 } // namespace ackermann

--- a/include/fake/plant.h
+++ b/include/fake/plant.h
@@ -131,12 +131,12 @@ class Plant {
   double speed_;
   double heading_;
 
+  // struct of our system options
+  PlantOptions opts_;
+
   /**
   * @brief A copy of our configuration parameters. */
   std::shared_ptr<const ackermann::Params> params_;
-
-  // struct of our system options
-  PlantOptions opts_;
 
   // random noise generation
   std::default_random_engine generator_;


### PR DESCRIPTION
This PR corrects all outstanding compiler warnings.